### PR TITLE
Make json escaping use the default ruby gem

### DIFF
--- a/_plugins/json.rb
+++ b/_plugins/json.rb
@@ -1,0 +1,9 @@
+require 'json'
+
+module JsonFilter
+  def json(input)
+    input.to_json
+  end
+
+  Liquid::Template.register_filter self
+end

--- a/feeds/feed.json
+++ b/feeds/feed.json
@@ -5,11 +5,11 @@ layout: none
 {% for post in site.posts %}
     {% if post.title != null and post.title != empty and post.search_omit != true %}
         {% if forloop.index > 1 %},{%endif%}{
-            "title": "{{post.title}} ",
-            "content": "{{post.content | markdownify | strip_html | strip_newlines | replace: '"', '\"'}}",
+            "title": {{post.title | json}},
+            "content": {{post.content | markdownify | strip_html | json}},
             "link": "{{ site.url }}{{ post.url }}",
-            "date": "{{ post.date }}",
-            "excerpt": "{{ post.snippet }}"
+            "date": {{ post.date | json }},
+            "excerpt": {{ post.snippet | json }}
         }
     {%endif%}
 {% endfor %}
@@ -17,11 +17,11 @@ layout: none
 {% for page in site.pages %}
     {% if page.layout != 'none' and page.layout != 'none' and page.title != null and page.title != empty and page.search_omit != true %}
         {% if forloop.index > 1 %},{%endif%}{
-            "title": "{{page.title}} ",
-            "content": "{{page.content | strip_html | strip_newlines | replace: '"', '\"'}}",
+            "title": {{page.title | json }},
+            "content": {{page.content | strip_html | strip_newlines | json}},
             "link": "{{ site.url }}{{ page.url | replace: 'index.html', '' }}",
-            "date": "{{ page.date }}",
-            "excerpt": "{{ page.description }}"
+            "date": {{ page.date | json }},
+            "excerpt": {{ page.description | json }}
         }
     {%endif%}
 {% endfor %}


### PR DESCRIPTION
This makes implementing a json template a bit simpler and more reliable. The
json escaping is delegated to the ruby 'json' gem.

I ran into an issue where my content contained characters that were not
escaped by the original feed.json implementation.
