### PR TITLE
Use Liquid's jsonify filter rather than a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Version history
 
 | Version no. | Description  | Date |
 | --- | --- | --- |
+| 0.2.1 | Used built-in jsonify filter (thanks to [davekinkead](https://github.com/davekinkead)) | 25 Sep 2014 |
 | 0.2 | Used built-in ruby JSON (thanks to [mrvdb](https://github.com/mrvdb)) | 20th May 2014 |
 | 0.1 | First draft | 24th February 2014 |
 

--- a/_plugins/json.rb
+++ b/_plugins/json.rb
@@ -1,9 +1,0 @@
-require 'json'
-
-module JsonFilter
-  def json(input)
-    input.to_json
-  end
-
-  Liquid::Template.register_filter self
-end

--- a/feeds/feed.json
+++ b/feeds/feed.json
@@ -5,23 +5,24 @@ layout: none
 {% for post in site.posts %}
     {% if post.title != null and post.title != empty and post.search_omit != true %}
         {% if forloop.index > 1 %},{%endif%}{
-            "title": {{post.title | json}},
-            "content": {{post.content | markdownify | strip_html | json}},
+            "title": {{ post.title | jsonify }},
+            "content": {{ post.content | markdownify | strip_html | jsonify }},
             "link": "{{ site.url }}{{ post.url }}",
-            "date": {{ post.date | json }},
-            "excerpt": {{ post.snippet | json }}
+            "date": {{ post.date | jsonify }},
+            "excerpt": {{ post.snippet | jsonify }}
         }
     {%endif%}
 {% endfor %}
-
+,
 {% for page in site.pages %}
     {% if page.layout != 'none' and page.layout != 'none' and page.title != null and page.title != empty and page.search_omit != true %}
-        {% if forloop.index > 1 %},{%endif%}{
-            "title": {{page.title | json }},
-            "content": {{page.content | strip_html | strip_newlines | json}},
+        {% if forloop.index > 1 %},{%endif%}
+        {
+            "title": {{ page.title | jsonify }},
+            "content": {{ page.content | strip_html | strip_newlines | jsonify }},
             "link": "{{ site.url }}{{ page.url | replace: 'index.html', '' }}",
-            "date": {{ page.date | json }},
-            "excerpt": {{ page.description | json }}
+            "date": {{ page.date | jsonify }},
+            "excerpt": {{ page.description | jsonify }}
         }
     {%endif%}
 {% endfor %}


### PR DESCRIPTION
Use the standard jsonify filter to properly escape collections and
remove the need for plugins.  Also added comma between posts & pages in
the feed for valid JSON output

See issue #3