### PR TITLE
Fix typo - seach_omit > search_omit :smile:

### DIFF
--- a/feeds/feed.json
+++ b/feeds/feed.json
@@ -13,7 +13,7 @@ layout: null
                 "link": "{{ site.url }}{{ item.url }}",
                 "date": "{{ item.date }}",
                 "excerpt": "{{ item.snippet }}",
-                "seach_omit": "{{ item.search_omit }}"
+                "search_omit": "{{ item.search_omit }}"
             }
             {% assign first = false %}
             {% endif %}
@@ -30,7 +30,7 @@ layout: null
         "link": "{{ site.url }}{{ post.url }}",
         "date": "{{ post.date }}",
         "excerpt": "{{ post.snippet }}",
-        "seach_omit": "{{ post.search_omit }}"
+        "search_omit": "{{ post.search_omit }}"
     }
     {% assign first = false %}
     {% endif %}
@@ -44,7 +44,7 @@ layout: null
         "link": "{{ site.url }}{{ page.url | replace: 'index.html', '' }}",
         "date": {{ page.date | jsonify }},
         "excerpt": {{ page.description | jsonify }},
-        "seach_omit": "{{ post.search_omit }}"
+        "search_omit": "{{ post.search_omit }}"
     }
     {% assign first = false %}
     {% endif %}


### PR DESCRIPTION
Not sure if this will fix an issue I am having with page's still being submitted to search feed, despite the presence of the search_omit: true entry in front matter.