### PR TITLE
Make $searchForm only hold selector string

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -12,7 +12,7 @@
     ========================================================================== */
 
 var q, jsonFeedUrl = "/feeds/feed.json",
-    $searchForm = $("[data-search-form]"),
+    $searchForm = "[data-search-form]",
     $searchInput = $("[data-search-input]"),
     $resultTemplate = $("#search-result"),
     $resultsPlaceholder = $("[data-search-results]"),


### PR DESCRIPTION
[`.on()`](http://api.jquery.com/on/) takes selector string, not list of objects.

Resolves #12 